### PR TITLE
add optional RAM encryption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/usbarmory/armory-boot v0.0.0-20230127111211-c78215862f3a
-	github.com/usbarmory/tamago v0.0.0-20230412093325-383c4e3b55d7
+	github.com/usbarmory/tamago v0.0.0-20230514185315-ab7c5d1ca6fe
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/usbarmory/armory-boot v0.0.0-20230127111211-c78215862f3a h1:Xrt6+HldF
 github.com/usbarmory/armory-boot v0.0.0-20230127111211-c78215862f3a/go.mod h1:cbJrWcoa2YHwd1ojpZoSp8pbe9WOK3qiynJChpFNRCM=
 github.com/usbarmory/tamago v0.0.0-20230412093325-383c4e3b55d7 h1:beRkefTQDcq3MYcBIhBHmz9bfUu0gBiS1sEwzRbcpBs=
 github.com/usbarmory/tamago v0.0.0-20230412093325-383c4e3b55d7/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
+github.com/usbarmory/tamago v0.0.0-20230514185315-ab7c5d1ca6fe h1:pU58Po6YJiLMiP+S75bgyShAEFPufd8OwVzigWKKvog=
+github.com/usbarmory/tamago v0.0.0-20230514185315-ab7c5d1ca6fe/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=


### PR DESCRIPTION
This PR adds external RAM encryption for the booted kernel, only on i.MX6UL P/Ns and when the BEE constant is overridden to true (e.g. for now this is disabled by default). The target kernel and its target applet must be compiled for aliased memory regions when this feature is enabled.