### PR TITLE
Make config package know about FT proofs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,9 +28,13 @@ const (
 
 // ProofBundle represents a firmware transparency proof bundle.
 type ProofBundle struct {
-	Checkpoint     []byte
-	Manifest       []byte
-	LogIndex       uint64
+	// Checkpoint is a note-formatted checkpoint from a log which contains Manifest, below.
+	Checkpoint []byte
+	// Manifest contains metadata about a firmware release.
+	Manifest []byte
+	// LogIndex is the position within the log where Manifest was included.
+	LogIndex uint64
+	// InclusionProof is a proof for Manifest@Index being committed to by Checkpoint.
 	InclusionProof [][]byte
 }
 
@@ -42,7 +46,8 @@ type Config struct {
 	Size int64
 	// Signatures are the unikernel signify/minisign signatures.
 	Signatures [][]byte
-
+	// Bundle contains firmware transparency artefacts relating to the firmware this config
+	// references.
 	Bundle ProofBundle
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,14 @@ const (
 	MaxLength = 40960
 )
 
+// ProofBundle represents a firmware transparency proof bundle.
+type ProofBundle struct {
+	Checkpoint     []byte
+	Manifest       []byte
+	LogIndex       uint64
+	InclusionProof [][]byte
+}
+
 // Config represents the armored-witness-boot configuration.
 type Config struct {
 	// Offset is the MMC/SD card offset to an ELF unikernel image (e.g. TamaGo).
@@ -36,6 +44,8 @@ type Config struct {
 	Signatures [][]byte
 
 	pubKeys []string
+
+	Bundle ProofBundle
 }
 
 // Encode serializes the configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,6 @@ type Config struct {
 	// Signatures are the unikernel signify/minisign signatures.
 	Signatures [][]byte
 
-	pubKeys []string
-
 	Bundle ProofBundle
 }
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -14,19 +14,22 @@
 
 //go:build linkramsize
 
-package config
+// crypto contains cryptographic verification support for the bootloader.
+package crypto
 
 import (
 	"encoding/json"
 	"fmt"
 	"log"
 
-	"github.com/usbarmory/armory-boot/config"
+	"github.com/transparency-dev/armored-witness-boot/config"
+	abc "github.com/usbarmory/armory-boot/config"
 )
 
 // Verify authenticates the armored-witness-boot configuration hash signatures.
-func (c *Config) Verify(buf []byte, pubKeys string, quorum int) (err error) {
-	if err = json.Unmarshal([]byte(pubKeys), &c.pubKeys); err != nil {
+func VerifyConfig(c config.Config, buf []byte, pubKeysJSON string, quorum int) (err error) {
+	var pubKeys []string
+	if err = json.Unmarshal([]byte(pubKeysJSON), &pubKeys); err != nil {
 		return
 	}
 
@@ -40,10 +43,10 @@ func (c *Config) Verify(buf []byte, pubKeys string, quorum int) (err error) {
 
 	n := 0
 
-	for i, pubKey := range c.pubKeys {
+	for i, pubKey := range pubKeys {
 		log.Printf("armored-witness-boot: authenticating kernel (%s)", pubKey)
 
-		if err = config.Verify(buf, c.Signatures[i], pubKey); err != nil {
+		if err = abc.Verify(buf, c.Signatures[i], pubKey); err != nil {
 			log.Printf("armored-witness-boot: %s, %v", pubKey, err)
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/usbarmory/armory-boot/exec"
 
 	"github.com/transparency-dev/armored-witness-boot/config"
+	"github.com/transparency-dev/armored-witness-boot/crypto"
 	"github.com/transparency-dev/armored-witness-boot/storage"
 )
 
@@ -81,7 +82,7 @@ func main() {
 		panic(fmt.Sprintf("kernel read error, %v\n", err))
 	}
 
-	if err = conf.Verify(kernel, PublicKeys, Quorum); err != nil {
+	if err = crypto.VerifyConfig(*conf, kernel, PublicKeys, Quorum); err != nil {
 		panic(fmt.Sprintf("configuration verification error, %v\n", err))
 	}
 


### PR DESCRIPTION
This PR is a step towards having the applet handle OS and applet updates.

It:
- adds a place to store firmware transparency info relating to the firmware image the config struct points to
- removes `imx6ul` specific deps from the `config` package, allowing it to be imported by the applet.

See transparency-dev/armored-witness-applet#98 and transparency-dev/armored-witness-os#47.