### PR TITLE
Log recovery image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+armored-witness-boot*
+armory-ums*

--- a/recovery/Dockerfile
+++ b/recovery/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.21-bookworm
+
+ARG TAMAGO_VERSION
+ARG ARMORY_UMS_VERSION
+ARG ARMORED_WITNESS_VERSION=228f2f6432babe1f1657e150ce0ca4a96ab394da
+
+# Install dependencies.
+RUN apt-get update && apt-get install -y make wget u-boot-tools binutils-arm-none-eabi
+
+RUN wget "https://github.com/usbarmory/tamago-go/releases/download/tamago-go${TAMAGO_VERSION}/tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz"
+RUN tar -xvf "tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz" -C /
+# Set Tamago path for Make rule.
+ENV TAMAGO=/usr/local/tamago-go/bin/go
+
+WORKDIR /build
+
+RUN git clone --branch ${ARMORY_UMS_VERSION} https://github.com/usbarmory/armory-ums.git
+RUN cd armory-ums && \
+    CROSS_COMPILE=arm-none-eabi- make imx && \
+    git rev-parse --verify HEAD > armory-ums.imx.git-commit

--- a/recovery/README.md
+++ b/recovery/README.md
@@ -1,0 +1,10 @@
+# Recovery
+
+The Dockerfile in this directory is used for building an image to be used as a
+recovery/provisioning tool for the armored witness.
+
+We currently use the firmware in the github.com/usbarmory/armory-ums repo as
+the recovery tool.
+
+While that repo does offer prebuilt binary releases, we rebuild from scratch
+here so we can be sure about which TamaGo toolchain version is used, etc.


### PR DESCRIPTION
This PR adds a target and supporting `Dockerfile` for building a local version of `armory-ums` and logging its metadata in the local DEV FT log.