### PR TITLE
Use a time-based semver version for dev builds, and log build versions at boot time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,13 @@
 
 BUILD_USER ?= $(shell whoami)
 BUILD_HOST ?= $(shell hostname)
+BUILD_EPOCH ?= $(shell /bin/date -u "+%s")
 BUILD_DATE ?= $(shell /bin/date -u "+%Y-%m-%d %H:%M:%S")
 BUILD_TAGS = linkramsize,linkramstart,linkprintk
 BUILD = ${BUILD_USER}@${BUILD_HOST} on ${BUILD_DATE}
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)
 LOG_ORIGIN ?= "DEV.armoredwitness.transparency.dev/${USER}"
-GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n 'v0.0.0+'`git rev-parse HEAD`) | tail -c +2 )
+GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n v0.0.${BUILD_EPOCH}+`git rev-parse HEAD`) | tail -c +2 )
 LOG_VERIFIER = $(shell test ${LOG_PUBLIC_KEY} && cat ${LOG_PUBLIC_KEY})
 OS_VERIFIERS = [\"$(shell test ${OS_PUBLIC_KEY1} && cat ${OS_PUBLIC_KEY1})\", \"$(shell test ${OS_PUBLIC_KEY2} && cat ${OS_PUBLIC_KEY2})\"]
 
@@ -39,7 +40,7 @@ GOENV := GO_EXTLINK_ENABLED=0 CGO_ENABLED=0 GOOS=tamago GOARM=7 GOARCH=arm
 TEXT_START := 0x90010000 # ramStart (defined in imx6/imx6ul/memory.go) + 0x10000
 TAMAGOFLAGS := -tags ${BUILD_TAGS} -trimpath \
 	-ldflags "-s -w -T $(TEXT_START) -E _rt0_arm_tamago -R 0x1000 \
-			  -X 'main.Build=${BUILD}' -X 'main.Revision=${REV}' \
+			  -X 'main.Build=${BUILD}' -X 'main.Revision=${REV}' -X 'main.Version=${GIT_SEMVER_TAG}' \
 			  -X 'main.OSLogOrigin=${LOG_ORIGIN}' \
 			  -X 'main.OSLogVerifier=${LOG_VERIFIER}' \
 			  -X 'main.OSManifestVerifiers=${OS_VERIFIERS}'"

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ const (
 var (
 	Build    string
 	Revision string
+	Version  string
 
 	OSLogOrigin         string
 	OSLogVerifier       string
@@ -116,6 +117,7 @@ func main() {
 
 	usbarmory.LED("blue", false)
 	usbarmory.LED("white", false)
+	log.Printf("armored-witness-boot: version %v", Version)
 
 	if len(OSManifestVerifiers) == 0 {
 		panic("armored-witness-boot: missing public keys, aborting")
@@ -149,9 +151,11 @@ func main() {
 		LogVerifer:        logVerifier,
 		ManifestVerifiers: manifestVerifiers,
 	}
-	if err := bv.Verify(*os); err != nil {
+	manifest, err := bv.Verify(*os)
+	if err != nil {
 		panic(fmt.Sprintf("armored-witness-boot: kernel verification error, %v", err))
 	}
+	log.Printf("armored-witness-boot: loaded kernel version %v", manifest.GitTagName)
 
 	// For reference, this is how we'd fall back to verifying signatures only.
 	if false {


### PR DESCRIPTION
This PR ensures that there is a vaguely sensible defined ordering for local dev builds by using unix epoch seconds as the patch version.
