### PR TITLE
Bump to TamaGo v1.21.3

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.20.6
+      TAMAGO_VERSION: 1.21.3
       TAMAGO: /usr/local/tamago-go/bin/go
       OS_PRIVATE_KEY1: /tmp/os1.sec
       OS_PUBLIC_KEY1: /tmp/os1.pub


### PR DESCRIPTION
This PR bumps the version of TamaGo used to build and test to 1.21.3 (required due to recent changes to support BEE), and adds a check to the Makefile to ensure that a TamaGo version at least this new is always used to compile binaries.