### PR TITLE
Fix manifest generation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ log_recovery: check_log
 		@echo "You need to set RECOVERY_PRIVATE_KEY variable"; \
 		exit 1; \
 	fi
-	docker build -t armory-ums-build -f recovery/Dockerfile --build-arg=TAMAGO_VERSION=${TAMAGO_SEMVER} --build-arg=ARMORY_UMS_VERSION=${ARMORY_UMS_RELEASE}  recovery/
+	docker build -t armory-ums-build -f recovery/Dockerfile --build-arg=TAMAGO_VERSION=${TAMAGO_SEMVER} --build-arg=ARMORY_UMS_VERSION=${ARMORY_UMS_RELEASE} --network=host  recovery/
 	docker create --name au-build armory-ums-build
 	docker cp au-build:/build/armory-ums/armory-ums.imx .
 	docker cp au-build:/build/armory-ums/armory-ums.imx.git-commit .

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ log_recovery: check_log
 	go run github.com/transparency-dev/armored-witness/cmd/manifest@228f2f6432babe1f1657e150ce0ca4a96ab394da \
 		create \
 		--git_tag=${ARMORY_UMS_GIT_TAG} \
-		--git_commit_fingerprint=$(shell cat armory-ums.imx.git-commit) \
+		--git_commit_fingerprint=$$(cat armory-ums.imx.git-commit) \
 		--firmware_file=${CURDIR}/armory-ums.imx \
 		--firmware_type=RECOVERY \
 		--private_key_file=${RECOVERY_PRIVATE_KEY} \


### PR DESCRIPTION
This PR fixes a bug with the `shell` expansion in the manifest generation, and adds a flag to the docker command to use the host network directly.