### PR TITLE
Bump TamaGo-go version to 1.21.5 for bootloader

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.21.3
+      TAMAGO_VERSION: 1.21.5
       TAMAGO: /usr/local/tamago-go/bin/go
       LOG_ORIGIN: throwaway.transparency.dev/armored-witness-boot/pr-build/0
       LOG_PRIVATE_KEY: /tmp/log.sec

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LOG_VERIFIER = $(shell test ${LOG_PUBLIC_KEY} && cat ${LOG_PUBLIC_KEY})
 OS_VERIFIERS = [\"$(shell test ${OS_PUBLIC_KEY1} && cat ${OS_PUBLIC_KEY1})\", \"$(shell test ${OS_PUBLIC_KEY2} && cat ${OS_PUBLIC_KEY2})\"]
 
 TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
-MINIMUM_TAMAGO_VERSION=1.21.3
+MINIMUM_TAMAGO_VERSION=1.21.5
 
 SHELL = /bin/bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness-boot
 
-go 1.20
+go 1.21.5
 
 require (
 	github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27

--- a/go.sum
+++ b/go.sum
@@ -7,9 +7,11 @@ github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd/go.mod h1:7I+3P
 github.com/go-errors/errors v1.0.2 h1:xMxH9j2fNg/L4hLn/4y3M0IUsn0M6Wbu/Uh9QlOfBh4=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pierrec/lz4/v4 v4.1.14 h1:+fL8AQEZtz/ijeNnpduH0bROTu0O3NZAlPjQxGn8LwE=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/transparency-dev/armored-witness-applet v0.0.0-20230918140527-29dcafed830b h1:d8bLTgqLrvH1VJyNUTAzLyY/Ux13s7QHb19vEcTum7E=
+github.com/transparency-dev/armored-witness-applet v0.0.0-20230918140527-29dcafed830b/go.mod h1:oZIrSasyvz0k1IUaN9Ir8CDum9E/EBxyCN8zQftH1HU=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 h1:PHklaeYyhPsbhWt+MnKpBvJrsJGkPEaU1JutMj4wNqM=

--- a/recovery/cloudbuild_ci.yaml
+++ b/recovery/cloudbuild_ci.yaml
@@ -131,7 +131,7 @@ substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci-1
   _MANUAL_TAG: 0.0.0
-  _TAMAGO_VERSION: '1.21.3'
+  _TAMAGO_VERSION: '1.21.5'
   # Log-related.
   _ARMORED_WITNESS_REPO_VERSION: d37d6b19ec4dbd1cad3586ae8ba3ec913829d718
   # This must correspond with the trailing number on the _FIRMWARE_BUCKET, _ORIGIN, _LOG_NAME values.

--- a/recovery/cloudbuild_presubmit.yaml
+++ b/recovery/cloudbuild_presubmit.yaml
@@ -55,6 +55,6 @@ steps:
 substitutions:
   # Build-related.
   _MANUAL_TAG: 0.0.0
-  _TAMAGO_VERSION: '1.21.3'
+  _TAMAGO_VERSION: '1.21.5'
   # Log-related.
   _ARMORED_WITNESS_REPO_VERSION: d37d6b19ec4dbd1cad3586ae8ba3ec913829d718

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -133,7 +133,7 @@ substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci-1
   _MANUAL_TAG: 0.0.0
-  _TAMAGO_VERSION: '1.21.3'
+  _TAMAGO_VERSION: '1.21.5'
   # Log-related.
   _ARMORED_WITNESS_REPO_VERSION: d37d6b19ec4dbd1cad3586ae8ba3ec913829d718
   # This must correspond with the trailing number on the _FIRMWARE_BUCKET, _ORIGIN, _LOG_NAME values.

--- a/release/cloudbuild_presubmit.yaml
+++ b/release/cloudbuild_presubmit.yaml
@@ -57,7 +57,7 @@ steps:
 substitutions:
   # Build-related.
   _MANUAL_TAG: 0.0.0
-  _TAMAGO_VERSION: '1.21.3'
+  _TAMAGO_VERSION: '1.21.5'
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/1
   # Log-related.
   _ARMORED_WITNESS_REPO_VERSION: d37d6b19ec4dbd1cad3586ae8ba3ec913829d718


### PR DESCRIPTION
There are some important TamaGo fixes in 1.21.5, this PR makes that the minimum version.

See also:
 - transparency-dev/armored-witness-applet/pull/200
 - transparency-dev/armored-witness-os/pull/135