### PR TITLE
Add HAB signing to CI build

### DIFF
--- a/recovery/cloudbuild_ci.yaml
+++ b/recovery/cloudbuild_ci.yaml
@@ -43,7 +43,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/usbarmory/crucible/cmd/habtool \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk1-rev4-ci \
           -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk2-rev4-ci \
@@ -56,7 +56,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/usbarmory/crucible/cmd/habtool \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificates/hab-csf1-rev4-ci \
           -A projects/armored-witness/locations/global/keyRings/hab-ci/cryptoKeys/hab-csf1-rev4-ci/cryptoKeyVersions/1 \

--- a/recovery/cloudbuild_ci.yaml
+++ b/recovery/cloudbuild_ci.yaml
@@ -63,6 +63,7 @@ steps:
           -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificates/hab-img1-rev4-ci \
           -B projects/armored-witness/locations/global/keyRings/hab-ci/cryptoKeys/hab-img1-rev4-ci/cryptoKeyVersions/1 \
           -x 1 \
+          -s \
           -t output/gcp_hab_rev4_ci_srk.srk \
           -i output/armory-ums.imx \
           -o output/armory-ums.csf

--- a/recovery/cloudbuild_ci.yaml
+++ b/recovery/cloudbuild_ci.yaml
@@ -36,6 +36,45 @@ steps:
         gcloud storage cp \
           output/armory-ums.imx \
           gs://${_FIRMWARE_BUCKET}/$(sha256sum output/armory-ums.imx | cut -f1 -d" ")
+  # HAB: Create SRK table & hash
+  # TODO(al): we should probably store the generated SRK/hash in a GCS bucket and then compare each time to ensure that nothing bad has happened with our PKI.
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/usbarmory/crucible/cmd/habtool \
+          -z gcp \
+          -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk1-rev4-ci \
+          -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk2-rev4-ci \
+          -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk3-rev4-ci \
+          -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk4-rev4-ci \
+          -o output/gcp_hab_rev4_ci_srk.hash \
+          -t output/gcp_hab_rev4_ci_srk.srk
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/usbarmory/crucible/cmd/habtool \
+          -z gcp \
+          -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificates/hab-csf1-rev4-ci \
+          -A projects/armored-witness/locations/global/keyRings/hab-ci/cryptoKeys/hab-csf1-rev4-ci/cryptoKeyVersions/1 \
+          -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificates/hab-img1-rev4-ci \
+          -B projects/armored-witness/locations/global/keyRings/hab-ci/cryptoKeys/hab-img1-rev4-ci/cryptoKeyVersions/1 \
+          -x 1 \
+          -t output/gcp_hab_rev4_ci_srk.srk \
+          -i output/armory-ums.imx \
+          -o output/armory-ums.csf
+  # Copy the HAB signature into the CAS
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        gcloud storage cp \
+          output/armory-ums.csf \
+          gs://${_FIRMWARE_BUCKET}/$(sha256sum output/armory-ums.csf | cut -f1 -d" ")
   ### Construct log entry / Claimant Model statement.
   # This step needs to be a bash script in order to substitute the fake tag in
   # the command args.
@@ -51,6 +90,8 @@ steps:
           --firmware_file=output/armory-ums.imx \
           --firmware_type=RECOVERY \
           --tamago_version=${_TAMAGO_VERSION} \
+          --hab_signature_file=output/armory-ums.csf \
+          --hab_target=ci \
           --raw \
           --output_file=output/recovery_manifest_unsigned.json
   # Sign the log entry.

--- a/recovery/cloudbuild_presubmit.yaml
+++ b/recovery/cloudbuild_presubmit.yaml
@@ -27,6 +27,35 @@ steps:
     args:
       - ls
       - output
+    # HAB: Create SRK table & hash
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/usbarmory/crucible/cmd/habtool \
+          -z gcp \
+          -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk1-rev0-presubmit \
+          -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk2-rev0-presubmit \
+          -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk3-rev0-presubmit \
+          -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk4-rev0-presubmit \
+          -o output/gcp_hab_rev0_presubmit_srk.hash \
+          -t output/gcp_hab_rev0_presubmit_srk.srk
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/usbarmory/crucible/cmd/habtool \
+          -z gcp \
+          -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificates/hab-csf1-rev0-presubmit \
+          -A projects/armored-witness/locations/global/keyRings/hab-presubmit/cryptoKeys/hab-csf1-rev0-presubmit/cryptoKeyVersions/1 \
+          -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificates/hab-img1-rev0-presubmit \
+          -B projects/armored-witness/locations/global/keyRings/hab-presubmit/cryptoKeys/hab-img1-rev0-presubmit/cryptoKeyVersions/1 \
+          -x 1 \
+          -t output/gcp_hab_rev0_presubmit_srk.srk \
+          -i output/armory-ums.imx \
+          -o output/armory-ums.csf
   ### Construct log entry / Claimant Model statement.
   # This step needs to be a bash script in order to substitute the fake tag in
   # the command args.
@@ -42,6 +71,8 @@ steps:
           --firmware_file=output/armory-ums.imx \
           --firmware_type=RECOVERY \
           --tamago_version=${_TAMAGO_VERSION} \
+          --hab_signature_file=output/armory-ums.csf \
+          --hab_target=ci \
           --raw \
           --output_file=output/recovery_manifest_unsigned.json
   # TODO: sign the log entry with github.com/transparency-dev/armored-witness/cmd/sign

--- a/recovery/cloudbuild_presubmit.yaml
+++ b/recovery/cloudbuild_presubmit.yaml
@@ -33,7 +33,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/usbarmory/crucible/cmd/habtool \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk1-rev0-presubmit \
           -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk2-rev0-presubmit \
@@ -46,7 +46,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/usbarmory/crucible/cmd/habtool \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificates/hab-csf1-rev0-presubmit \
           -A projects/armored-witness/locations/global/keyRings/hab-presubmit/cryptoKeys/hab-csf1-rev0-presubmit/cryptoKeyVersions/1 \

--- a/recovery/cloudbuild_presubmit.yaml
+++ b/recovery/cloudbuild_presubmit.yaml
@@ -53,6 +53,7 @@ steps:
           -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificates/hab-img1-rev0-presubmit \
           -B projects/armored-witness/locations/global/keyRings/hab-presubmit/cryptoKeys/hab-img1-rev0-presubmit/cryptoKeyVersions/1 \
           -x 1 \
+          -s \
           -t output/gcp_hab_rev0_presubmit_srk.srk \
           -i output/armory-ums.imx \
           -o output/armory-ums.csf

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -52,6 +52,44 @@ steps:
         gcloud storage cp \
           output/armored-witness-boot.imx \
           gs://${_FIRMWARE_BUCKET}/$(sha256sum output/armored-witness-boot.imx | cut -f1 -d" ")
+  # HAB: Create SRK table & hash
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+          -z gcp \
+          -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk1-rev4-ci \
+          -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk2-rev4-ci \
+          -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk3-rev4-ci \
+          -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk4-rev4-ci \
+          -o output/gcp_hab_rev4_ci_srk.hash \
+          -t output/gcp_hab_rev4_ci_srk.srk-ca
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+          -z gcp \
+          -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificates/hab-csf1-rev4-ci \
+          -A projects/armored-witness/locations/global/keyRings/hab-ci/cryptoKeys/hab-csf1-rev4-ci/cryptoKeyVersions/1 \
+          -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificates/hab-img1-rev4-ci \
+          -B projects/armored-witness/locations/global/keyRings/hab-ci/cryptoKeys/hab-img1-rev4-ci/cryptoKeyVersions/1 \
+          -x 1 \
+          -t output/gcp_hab_rev4_ci_srk.srk \
+          -i output/armored-witness-boot.imx \
+          -o output/armored-witness-boot.csf
+  # Copy the HAB signature into the CAS
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        gcloud storage cp \
+          output/armored-witness-boot.csf \
+          gs://${_FIRMWARE_BUCKET}/$(sha256sum output/armored-witness-boot.csf | cut -f1 -d" ")
   ### Construct log entry / Claimant Model statement.
   # This step needs to be a bash script in order to substitute the fake tag in
   # the command args.
@@ -69,6 +107,8 @@ steps:
           --tamago_version=${_TAMAGO_VERSION} \
           --build_env="BEE=${_BEE}" \
           --build_env="CONSOLE=${_CONSOLE}" \
+          --hab_signature_file=output/armored-witness-boot.csf \
+          --hab_target=ci \
           --raw \
           --output_file=output/boot_manifest_unsigned.json
   # Sign the log entry.

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -53,6 +53,7 @@ steps:
           output/armored-witness-boot.imx \
           gs://${_FIRMWARE_BUCKET}/$(sha256sum output/armored-witness-boot.imx | cut -f1 -d" ")
   # HAB: Create SRK table & hash
+  # TODO(al): we should probably store the generated SRK/hash in a GCS bucket and then compare each time to ensure that nothing bad has happened with our PKI.
   - name: golang
     entrypoint: bash
     args:

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -66,7 +66,7 @@ steps:
           -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk3-rev4-ci \
           -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk4-rev4-ci \
           -o output/gcp_hab_rev4_ci_srk.hash \
-          -t output/gcp_hab_rev4_ci_srk.srk-ca
+          -t output/gcp_hab_rev4_ci_srk.srk
   - name: golang
     entrypoint: bash
     args:

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -147,7 +147,6 @@ steps:
       - -c
       - >
         gcloud functions call sequence \
-
         --data="{
           \"entriesDir\": \"${_ENTRIES_DIR}/$(sha256sum output/boot_manifest | cut -f1 -d" ")\",
           \"origin\": \"${_ORIGIN}\",

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -59,7 +59,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk1-rev4-ci \
           -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificateAuthorities/hab-srk2-rev4-ci \
@@ -72,7 +72,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-ci/certificates/hab-csf1-rev4-ci \
           -A projects/armored-witness/locations/global/keyRings/hab-ci/cryptoKeys/hab-csf1-rev4-ci/cryptoKeyVersions/1 \

--- a/release/cloudbuild_presubmit.yaml
+++ b/release/cloudbuild_presubmit.yaml
@@ -29,6 +29,35 @@ steps:
     args:
       - ls
       - output
+  # HAB: Create SRK table & hash
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+          -z gcp \
+          -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk1-rev0-presubmit \
+          -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk2-rev0-presubmit \
+          -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk3-rev0-presubmit \
+          -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk4-rev0-presubmit \
+          -o output/gcp_hab_rev0_presubmit_srk.hash \
+          -t output/gcp_hab_rev0_presubmit_srk.srk
+  - name: golang
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+          -z gcp \
+          -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificates/hab-csf1-rev0-presubmit \
+          -A projects/armored-witness/locations/global/keyRings/hab-presubmit/cryptoKeys/hab-csf1-rev0-presubmit/cryptoKeyVersions/1 \
+          -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificates/hab-img1-rev0-presubmit \
+          -B projects/armored-witness/locations/global/keyRings/hab-presubmit/cryptoKeys/hab-img1-rev0-presubmit/cryptoKeyVersions/1 \
+          -x 1 \
+          -t output/gcp_hab_rev0_presubmit_srk.srk \
+          -i output/armored-witness-boot.imx \
+          -o output/armored-witness-boot.csf
   ### Construct log entry / Claimant Model statement.
   # This step needs to be a bash script in order to substitute the fake tag in
   # the command args.
@@ -44,6 +73,8 @@ steps:
           --firmware_file=output/armored-witness-boot.imx \
           --firmware_type=BOOTLOADER \
           --tamago_version=${_TAMAGO_VERSION} \
+          --hab_signature_file=output/armored-witness-boot.csf \
+          --hab_target=presubmit \
           --raw \
           --output_file=output/boot_manifest_unsigned.json
   # TODO: sign the log entry with github.com/transparency-dev/armored-witness/cmd/sign
@@ -58,4 +89,4 @@ substitutions:
   # Build-related.
   _MANUAL_TAG: 0.0.0
   _TAMAGO_VERSION: '1.21.5'
-  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/1
+  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/presubmit/1

--- a/release/cloudbuild_presubmit.yaml
+++ b/release/cloudbuild_presubmit.yaml
@@ -35,7 +35,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk1-rev0-presubmit \
           -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificateAuthorities/hab-srk2-rev0-presubmit \
@@ -48,7 +48,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/AlCutter/crucible/cmd/habtool@gcloud_support \
+        go run github.com/AlCutter/crucible/cmd/habtool@e0a261c1492935c32b0fd57993c77573ae51c49d \
           -z gcp \
           -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-presubmit/certificates/hab-csf1-rev0-presubmit \
           -A projects/armored-witness/locations/global/keyRings/hab-presubmit/cryptoKeys/hab-csf1-rev0-presubmit/cryptoKeyVersions/1 \


### PR DESCRIPTION
This PR adds support for creating HAB signatures on CI `bootloader` and `recovery` builds.

TODO:  #79 update GCB configs to use canonical `crucible` repo