### PR TITLE
Set SOURCE_DATE_EPOCH properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,11 +231,12 @@ $(APP).bin: $(APP)
 	    -j .noptrbss --set-section-flags .noptrbss=alloc,load,contents \
 	    $(APP) -O binary $(APP).bin
 
+$(APP).imx: SOURCE_DATE_EPOCH=0
 $(APP).imx: $(APP).bin $(APP).dcd
 	echo "## disabling TZASC bypass in DCD for pre-DDR initialization ##"; \
 	chmod 644 $(APP).dcd; \
 	echo "DATA 4 0x020e4024 0x00000001  # TZASC_BYPASS" >> $(APP).dcd; \
-	SOURCE_DATE_EPOCH=0 mkimage -n $(APP).dcd -T imximage -e $(TEXT_START) -d $(APP).bin $(APP).imx
+	mkimage -v -n $(APP).dcd -T imximage -e $(TEXT_START) -d $(APP).bin $(APP).imx
 	# Copy entry point from ELF file
 	dd if=$(APP) of=$(APP).imx bs=1 count=4 skip=24 seek=4 conv=notrunc
 


### PR DESCRIPTION
Previously this wasn't exporting the `SOURCE_DATE_EPOCH` variable into the `mkimage` process, so it wasn't having the desired effect.