### PR TITLE
Commit to all build envs in manifest

### DIFF
--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -16,11 +16,11 @@ steps:
       - |
         docker build \
           --build-arg=TAMAGO_VERSION=${_TAMAGO_VERSION} \
+          --build-arg=GIT_SEMVER_TAG=$(cat /workspace/fake_tag) \
           --build-arg=LOG_ORIGIN=${_ORIGIN} \
           --build-arg=LOG_PUBLIC_KEY=${_LOG_PUBLIC_KEY} \
           --build-arg=OS_PUBLIC_KEY1=${_OS_PUBLIC_KEY1} \
           --build-arg=OS_PUBLIC_KEY2=${_OS_PUBLIC_KEY2} \
-          --build-arg=GIT_SEMVER_TAG=$(cat /workspace/fake_tag) \
           --build-arg=BEE=${_BEE} \
           --build-arg=CONSOLE=${_CONSOLE} \
           -t builder-image \
@@ -106,6 +106,10 @@ steps:
           --firmware_file=output/armored-witness-boot.imx \
           --firmware_type=BOOTLOADER \
           --tamago_version=${_TAMAGO_VERSION} \
+          --build_env="LOG_ORIGIN=${_ORIGIN}" \
+          --build_env="LOG_PUBLIC_KEY=${_LOG_PUBLIC_KEY}" \
+          --build_env="OS_PUBLIC_KEY1=${_OS_PUBLIC_KEY1}" \
+          --build_env="OS_PUBLIC_KEY2=${_OS_PUBLIC_KEY2}" \
           --build_env="BEE=${_BEE}" \
           --build_env="CONSOLE=${_CONSOLE}" \
           --hab_signature_file=output/armored-witness-boot.csf \


### PR DESCRIPTION
Any of these values could be rotated in the future, and given they are critical for reproducible builds they should be in the manifest. One could argue that these should have their own top-level named entry in the manifest rather than being buried in build_envs. For pragmatism, let's use this approach for now and we can revisit this in a month as part of a whole manifest refactor before we commit to v1.
