### PR TITLE
Bump go and tamago to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LOG_VERIFIER = $(shell test ${LOG_PUBLIC_KEY} && cat ${LOG_PUBLIC_KEY})
 OS_VERIFIERS = [\"$(shell test ${OS_PUBLIC_KEY1} && cat ${OS_PUBLIC_KEY1})\", \"$(shell test ${OS_PUBLIC_KEY2} && cat ${OS_PUBLIC_KEY2})\"]
 
 TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
-MINIMUM_TAMAGO_VERSION=1.22.0
+MINIMUM_TAMAGO_VERSION=1.22.6
 
 SHELL = /bin/bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness-boot
 
-go 1.22.0
+go 1.22.6
 
 require (
 	github.com/transparency-dev/armored-witness-common v0.0.0-20240220112235-78461719cb5e


### PR DESCRIPTION
Started on this journey because https://github.com/transparency-dev/armored-witness-common/pull/36 failed due to old version. May as well bring everything up to the latest version of tamago.
